### PR TITLE
fix: update repository URLs after rename from harper-agent to agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
 	"description": "AI to help you with Harper app management",
 	"version": "0.16.17",
 	"main": "dist/cli.js",
-	"repository": "github:HarperFast/harper-agent",
+	"repository": "github:HarperFast/agent",
 	"bugs": {
-		"url": "https://github.com/harperfast/harper-agent/issues"
+		"url": "https://github.com/HarperFast/agent/issues"
 	},
 	"homepage": "https://github.com/harperfast",
 	"scripts": {


### PR DESCRIPTION
Fixes the semantic-release `EMISMATCHGITHUBURL` failure in CI.

When the repo was renamed from `harper-agent` to `agent`, two stale URLs were left in `package.json`:
- `repository`: `github:HarperFast/harper-agent` → `github:HarperFast/agent`
- `bugs.url`: `https://github.com/harperfast/harper-agent/issues` → `https://github.com/HarperFast/agent/issues`

The `bin` entry (`"harper-agent": "./dist/cli.js"`) is intentionally unchanged — that's the CLI command name, not a repo reference.