### PR TITLE
fix(test): flush effects before writing input in MainConfig walkthrough tests

### DIFF
--- a/ink/main.test.tsx
+++ b/ink/main.test.tsx
@@ -1,7 +1,7 @@
 import { useApp } from 'ink';
 import { render } from 'ink-testing-library';
 import { existsSync, writeFileSync } from 'node:fs';
-import React from 'react';
+import React, { act } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchOllamaModels } from '../utils/ollama/fetchOllamaModels';
 import { emitToListeners } from './emitters/listener';
@@ -31,16 +31,47 @@ const down = '\u001B[B';
 // const left = '\u001B[D';
 const enter = '\r';
 
+// Ink paints a frame during render, but `useInput` subscribes to stdin in a
+// passive effect. Between those two points the previous step is what is still
+// listening, so a write made after only asserting on the frame is delivered to
+// the step we just left and silently dropped. Flushing effects closes that gap.
+const settle = () => act(async () => {});
+
 // Ink re-renders asynchronously after stdin writes; polling for the expected
 // frame avoids the flakiness of a fixed-duration sleep under CI load.
-const waitForFrame = (lastFrame: () => string | undefined, text: string) =>
-	vi.waitFor(() => expect(lastFrame()).toContain(text));
+const waitForFrame = async (lastFrame: () => string | undefined, text: string) => {
+	await vi.waitFor(() => expect(lastFrame()).toContain(text));
+	await settle();
+};
 
-// ApiKeyStep renders input as a password field, masking typed characters as
-// `*`. Wait for the masked value before submitting so the keystrokes have
-// actually reached component state.
-const waitForMaskedInput = (lastFrame: () => string | undefined, text: string) =>
-	vi.waitFor(() => expect(lastFrame()).toContain('*'.repeat(text.length)));
+// ApiKeyStep renders input as a password field, masking typed characters as `*`.
+const maskFor = (value: string) => '*'.repeat(value.length);
+
+// ProviderStep sorts the current provider first and the rest alphabetically, so
+// from the default (OpenAI) this is the order the down arrow walks. Confirming
+// each highlight in turn means a keypress that has not landed yet fails here
+// rather than selecting the wrong provider further down.
+const providerOrder = ['OpenAI', 'Anthropic', 'Google', 'Ollama'];
+
+const selectProvider = async (
+	lastFrame: () => string | undefined,
+	stdin: { write: (data: string) => void },
+	provider: string,
+) => {
+	const target = providerOrder.indexOf(provider);
+	if (target === -1) {
+		// Without this the slice below is empty and the walkthrough would quietly
+		// run against the default provider instead of the one asked for.
+		throw new Error(`Unknown provider ${provider}, expected one of ${providerOrder.join(', ')}`);
+	}
+
+	await waitForFrame(lastFrame, 'What model provider would you like to use today?');
+	for (const name of providerOrder.slice(1, target + 1)) {
+		stdin.write(down);
+		await waitForFrame(lastFrame, `❯ ${name}`);
+	}
+	stdin.write(enter);
+};
 
 describe('MainConfig', () => {
 	const mockExit = vi.fn();
@@ -72,10 +103,13 @@ describe('MainConfig', () => {
 		expect(lastFrame()).toContain('What model provider would you like to use today?');
 	});
 
-	it('calls exit when ExitUI event is emitted', () => {
+	it('calls exit when ExitUI event is emitted', async () => {
 		const onComplete = vi.fn();
 		render(<MainConfig onComplete={onComplete} />);
 
+		// useListener subscribes in an effect, so emitting before effects flush
+		// would miss the listener entirely.
+		await settle();
 		emitToListeners('ExitUI', undefined);
 
 		expect(mockExit).toHaveBeenCalled();
@@ -86,13 +120,12 @@ describe('MainConfig', () => {
 		const { lastFrame, stdin } = render(<MainConfig onComplete={onComplete} />);
 
 		// 1. ProviderStep - Choose OpenAI (default)
-		await waitForFrame(lastFrame, 'What model provider would you like to use today?');
-		stdin.write(enter);
+		await selectProvider(lastFrame, stdin, 'OpenAI');
 
 		// 2. ApiKeyStep
 		await waitForFrame(lastFrame, 'Can you provide us with your OpenAI API key?');
 		stdin.write('sk-test-key');
-		await waitForMaskedInput(lastFrame, 'sk-test-key');
+		await waitForFrame(lastFrame, maskFor('sk-test-key'));
 		stdin.write(enter);
 
 		// 3. ModelSelectionStep - Model
@@ -122,14 +155,12 @@ describe('MainConfig', () => {
 		const { lastFrame, stdin } = render(<MainConfig onComplete={onComplete} />);
 
 		// 1. ProviderStep - Choose Anthropic
-		await waitForFrame(lastFrame, 'What model provider would you like to use today?');
-		stdin.write(down); // to Anthropic
-		stdin.write(enter);
+		await selectProvider(lastFrame, stdin, 'Anthropic');
 
 		// 2. ApiKeyStep
 		await waitForFrame(lastFrame, 'Can you provide us with your Anthropic API key?');
 		stdin.write('sk-ant-test-key');
-		await waitForMaskedInput(lastFrame, 'sk-ant-test-key');
+		await waitForFrame(lastFrame, maskFor('sk-ant-test-key'));
 		stdin.write(enter);
 
 		// 3. ModelSelectionStep - Model
@@ -159,15 +190,12 @@ describe('MainConfig', () => {
 		const { lastFrame, stdin } = render(<MainConfig onComplete={onComplete} />);
 
 		// 1. ProviderStep - Choose Google
-		await waitForFrame(lastFrame, 'What model provider would you like to use today?');
-		stdin.write(down); // to Anthropic
-		stdin.write(down); // to Google
-		stdin.write(enter);
+		await selectProvider(lastFrame, stdin, 'Google');
 
 		// 2. ApiKeyStep
 		await waitForFrame(lastFrame, 'Can you provide us with your Google API key?');
 		stdin.write('google-test-key');
-		await waitForMaskedInput(lastFrame, 'google-test-key');
+		await waitForFrame(lastFrame, maskFor('google-test-key'));
 		stdin.write(enter);
 
 		// 3. ModelSelectionStep - Model
@@ -197,12 +225,7 @@ describe('MainConfig', () => {
 		const { lastFrame, stdin } = render(<MainConfig onComplete={onComplete} />);
 
 		// 1. ProviderStep - Choose Ollama
-		await waitForFrame(lastFrame, 'What model provider would you like to use today?');
-
-		stdin.write(down); // to Anthropic
-		stdin.write(down); // to Google
-		stdin.write(down); // to Ollama
-		stdin.write(enter);
+		await selectProvider(lastFrame, stdin, 'Ollama');
 
 		// 2. ApiUrlStep (since provider is Ollama)
 		await waitForFrame(lastFrame, 'Where are you hosting Ollama?');

--- a/ink/main.test.tsx
+++ b/ink/main.test.tsx
@@ -4,6 +4,7 @@ import { existsSync, writeFileSync } from 'node:fs';
 import React, { act } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchOllamaModels } from '../utils/ollama/fetchOllamaModels';
+import { providers } from './configurationWizard/providers';
 import { emitToListeners } from './emitters/listener';
 import { MainConfig } from './main';
 
@@ -47,29 +48,26 @@ const waitForFrame = async (lastFrame: () => string | undefined, text: string) =
 // ApiKeyStep renders input as a password field, masking typed characters as `*`.
 const maskFor = (value: string) => '*'.repeat(value.length);
 
-// ProviderStep sorts the current provider first and the rest alphabetically, so
-// from the default (OpenAI) this is the order the down arrow walks. Confirming
-// each highlight in turn means a keypress that has not landed yet fails here
-// rather than selecting the wrong provider further down.
-const providerOrder = ['OpenAI', 'Anthropic', 'Google', 'Ollama'];
-
+// Walk the highlight down to `provider` rather than assuming how ProviderStep
+// sorts its options, so this keeps working if that sort changes. Stepping one row
+// at a time (instead of writing several downs then enter) means a keypress that
+// has not landed yet fails here rather than selecting the wrong provider.
 const selectProvider = async (
 	lastFrame: () => string | undefined,
 	stdin: { write: (data: string) => void },
 	provider: string,
 ) => {
-	const target = providerOrder.indexOf(provider);
-	if (target === -1) {
-		// Without this the slice below is empty and the walkthrough would quietly
-		// run against the default provider instead of the one asked for.
-		throw new Error(`Unknown provider ${provider}, expected one of ${providerOrder.join(', ')}`);
+	const highlighted = `❯ ${provider}`;
+	await waitForFrame(lastFrame, 'What model provider would you like to use today?');
+
+	// Bounded by the option count so a label that never highlights fails the
+	// assertion below rather than looping forever.
+	for (let row = 0; row < providers.length && !lastFrame()?.includes(highlighted); row++) {
+		stdin.write(down);
+		await settle();
 	}
 
-	await waitForFrame(lastFrame, 'What model provider would you like to use today?');
-	for (const name of providerOrder.slice(1, target + 1)) {
-		stdin.write(down);
-		await waitForFrame(lastFrame, `❯ ${name}`);
-	}
+	await waitForFrame(lastFrame, highlighted);
 	stdin.write(enter);
 };
 


### PR DESCRIPTION
## Summary

Fixes the `MainConfig` walkthrough tests in `ink/main.test.tsx`, which were failing on roughly **two of every three CI runs** and blocking every PR in this repo.

## The cause

It looked like timing flake — the failing test case and assertion moved between runs — but there's a specific mechanism.

Ink paints a frame during **render**, while `useInput` subscribes to stdin in a **passive effect**. Between those two points, the step being *left* is still the one listening. `waitForFrame` polled `lastFrame()`, so it returned as soon as the new step painted — before that step's `useInput` had subscribed — and the following `stdin.write` went to the outgoing step's handlers and was dropped.

I confirmed this by instrumenting ink's `useInput`. After advancing to `ApiKeyStep`, the handlers actually invoked for the API-key write were still ProviderStep's `onExit` and its `Select`'s `focusNextOption`; `ApiKeyStep`'s and `BlinkingTextInput`'s handlers subscribed only *afterwards*:

```
emitInput "sk-test-key"  → INVOKE Select.focusNextOption + ProviderStep.onExit   (stale)
UNSUB (ProviderStep, Select)      ← effects flush only now
SUB   (BlinkingTextInput, ApiKeyStep)
```

That also explains why 1c67a48 (fixed sleeps → polling) didn't settle it: the sleeps had been *incidentally* covering the effect flush that polling no longer waits for.

## The change

- `waitForFrame` awaits `act()` after its frame assertion, so effects commit before the next keystroke.
- Arrow-key navigation had the same gap — `down` and `enter` were written back to back, so a `down` that hadn't landed would silently select the wrong provider. `selectProvider` now confirms one highlight at a time.
- The ExitUI test gets the same `settle()`, since `useListener` also subscribes in an effect. It passes today but was latently racy.
- `waitForMaskedInput` collapsed into `maskFor()` + `waitForFrame`; its old signature took a `text` argument and used only its `.length`, which was misleading.

## Verification

Clean worktree, Node 24.17:

| | result |
|---|---|
| previous test (control, same worktree) | **4/4 runs failed** |
| this version | **10/10 runs passed** |
| full suite | 53 files / 345 tests green |
| `dprint check`, `oxlint`, `npm run build` | clean |

## Where to look

- **`selectProvider` makes no ordering assumption.** It walks the highlight down until the requested provider is selected, so it survives changes to `ProviderStep`'s sort; `providers` supplies only the loop bound. (First revision hardcoded the order — @gemini-code-assist flagged the duplication, addressed in 43d86eb.)
- **`act()` from `react` on an ink tree.** It flushes ink's reconciler because ink builds on `react-reconciler`, and no act-environment warnings appear. Worth a sanity check if you've seen ink and `act` interact badly before.
- **Product behaviour is untouched.** The same gap exists at runtime in principle — a keystroke arriving between a step's render and its effect commit would be dropped — but a human types far slower than the flush, so I treated this as test-only rather than reworking the wizard. Flagging it in case you'd rather harden `ConfigurationWizard` instead.

Both commits were verified the same way (10/10 runs, full suite green, format/lint/build clean).

Note the step-10 cross-model review was **not** run: the `cross-model-review` skill isn't installed in this environment, and spawning a Claude reviewer would defeat its purpose. This is a test-only change, but the `act()` choice and the ordering coupling above are the spots that would most benefit from a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
