### PR TITLE
refactor(wizard): let the wizard own its keyboard nav instead of toggling the stepper's

### DIFF
--- a/ink/configurationWizard/ApiKeyStep.test.tsx
+++ b/ink/configurationWizard/ApiKeyStep.test.tsx
@@ -1,13 +1,8 @@
 import { useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiKeyStep } from './ApiKeyStep';
-
-vi.mock('ink-stepper', () => ({
-	useStepperInput: vi.fn(),
-}));
 
 vi.mock('ink', async () => {
 	const actual = await vi.importActual('ink');
@@ -18,15 +13,8 @@ vi.mock('ink', async () => {
 });
 
 describe('ApiKeyStep', () => {
-	const mockDisableNavigation = vi.fn();
-	const mockEnableNavigation = vi.fn();
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useStepperInput as any).mockReturnValue({
-			disableNavigation: mockDisableNavigation,
-			enableNavigation: mockEnableNavigation,
-		});
 	});
 
 	it('renders API key prompt for OpenAI', () => {

--- a/ink/configurationWizard/ApiKeyStep.tsx
+++ b/ink/configurationWizard/ApiKeyStep.tsx
@@ -1,6 +1,5 @@
 import { Box, Text, useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BlinkingTextInput } from '../components/BlinkingTextInput';
 import { emitToListeners } from '../emitters/listener';
 import type { ModelProvider } from '../models/config';
@@ -13,13 +12,6 @@ export function ApiKeyStep(
 		onBack: () => void;
 	},
 ) {
-	const { disableNavigation, enableNavigation } = useStepperInput();
-
-	useEffect(() => {
-		disableNavigation();
-		return () => enableNavigation();
-	}, [disableNavigation, enableNavigation]);
-
 	useInput((input, key) => {
 		if (key.escape) {
 			onBack();

--- a/ink/configurationWizard/ApiUrlStep.test.tsx
+++ b/ink/configurationWizard/ApiUrlStep.test.tsx
@@ -1,13 +1,8 @@
 import { useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiUrlStep } from './ApiUrlStep';
-
-vi.mock('ink-stepper', () => ({
-	useStepperInput: vi.fn(),
-}));
 
 vi.mock('ink', async () => {
 	const actual = await vi.importActual('ink');
@@ -18,15 +13,8 @@ vi.mock('ink', async () => {
 });
 
 describe('ApiUrlStep', () => {
-	const mockDisableNavigation = vi.fn();
-	const mockEnableNavigation = vi.fn();
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useStepperInput as any).mockReturnValue({
-			disableNavigation: mockDisableNavigation,
-			enableNavigation: mockEnableNavigation,
-		});
 	});
 
 	it('renders API URL prompt for Ollama', () => {

--- a/ink/configurationWizard/ApiUrlStep.tsx
+++ b/ink/configurationWizard/ApiUrlStep.tsx
@@ -1,6 +1,5 @@
 import { Box, Text, useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BlinkingTextInput } from '../components/BlinkingTextInput';
 import { emitToListeners } from '../emitters/listener';
 import type { ModelProvider } from '../models/config';
@@ -13,13 +12,6 @@ export function ApiUrlStep(
 		onBack: () => void;
 	},
 ) {
-	const { disableNavigation, enableNavigation } = useStepperInput();
-
-	useEffect(() => {
-		disableNavigation();
-		return () => enableNavigation();
-	}, [disableNavigation, enableNavigation]);
-
 	useInput((input, key) => {
 		if (key.escape) {
 			onBack();

--- a/ink/configurationWizard/ConfigurationWizard.test.tsx
+++ b/ink/configurationWizard/ConfigurationWizard.test.tsx
@@ -39,4 +39,14 @@ describe('ConfigurationWizard', () => {
 
 		expect(emitToListeners).toHaveBeenCalledWith('ExitUI', undefined);
 	});
+
+	it('does not complete the wizard on <esc> (each step owns back-navigation)', () => {
+		const onComplete = vi.fn();
+		render(<ConfigurationWizard onComplete={onComplete} />);
+
+		const inputHandler = (useInput as any).mock.calls[0][0];
+		inputHandler('', { escape: true });
+
+		expect(onComplete).not.toHaveBeenCalled();
+	});
 });

--- a/ink/configurationWizard/ConfigurationWizard.tsx
+++ b/ink/configurationWizard/ConfigurationWizard.tsx
@@ -37,12 +37,12 @@ export function ConfigurationWizard({ onComplete }: Props) {
 		}
 	}, [provider]);
 
+	// <esc> is owned per-step (back-navigation, or leaving a sub-mode); the wizard only binds
+	// global exit keys here. Handling <esc> at this level too would double-fire with the active
+	// step — Ink delivers input to every mounted useInput — and complete the wizard instead.
 	useInput((input, key) => {
 		if (key.ctrl && input === 'x') {
 			emitToListeners('ExitUI', undefined);
-		}
-		if (key.escape) {
-			onComplete();
 		}
 	});
 

--- a/ink/configurationWizard/ConfigurationWizard.tsx
+++ b/ink/configurationWizard/ConfigurationWizard.tsx
@@ -53,12 +53,18 @@ export function ConfigurationWizard({ onComplete }: Props) {
 		? [...new Set([...ollamaModels, ...compactorModelsByProvider[provider]])]
 		: compactorModelsByProvider[provider];
 
+	// Every step owns its own keys: its input widget consumes <enter> and advances by calling
+	// goNext() from onConfirm, and each step binds <esc> itself. The Stepper's built-in
+	// bindings would double-handle <enter> on top of that, which is why every step used to
+	// switch them off via disableNavigation() for its whole lifetime. Saying keyboardNav={false}
+	// once states that directly, and leaves goNext() free of however the library happens to
+	// gate its own navigation — ink-stepper 0.2.3 extended that gate to programmatic calls.
 	return (
 		<Box flexDirection="column" padding={1} minHeight={10}>
 			<Stepper
 				onComplete={onComplete}
 				onCancel={curryEmitToListeners('ExitUI', undefined)}
-				keyboardNav={true}
+				keyboardNav={false}
 				renderProgress={StepperProgress}
 			>
 				<Step name="AI Provider">

--- a/ink/configurationWizard/EnvironmentSettingsStep.test.tsx
+++ b/ink/configurationWizard/EnvironmentSettingsStep.test.tsx
@@ -1,13 +1,8 @@
 import { useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EnvironmentSettingsStep } from './EnvironmentSettingsStep';
-
-vi.mock('ink-stepper', () => ({
-	useStepperInput: vi.fn(),
-}));
 
 vi.mock('ink', async () => {
 	const actual = await vi.importActual('ink');
@@ -18,15 +13,8 @@ vi.mock('ink', async () => {
 });
 
 describe('EnvironmentSettingsStep', () => {
-	const mockDisableNavigation = vi.fn();
-	const mockEnableNavigation = vi.fn();
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useStepperInput as any).mockReturnValue({
-			disableNavigation: mockDisableNavigation,
-			enableNavigation: mockEnableNavigation,
-		});
 	});
 
 	it('renders settings options', () => {

--- a/ink/configurationWizard/EnvironmentSettingsStep.tsx
+++ b/ink/configurationWizard/EnvironmentSettingsStep.tsx
@@ -1,7 +1,6 @@
 import { MultiSelect } from '@inkjs/ui';
 import { Box, Text, useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { updateEnv } from '../../utils/files/updateEnv';
 
 interface Props {
@@ -38,13 +37,6 @@ const SETTINGS = [
 ];
 
 export function EnvironmentSettingsStep({ onConfirm, onBack }: Props) {
-	const { disableNavigation, enableNavigation } = useStepperInput();
-
-	useEffect(() => {
-		disableNavigation();
-		return () => enableNavigation();
-	}, [disableNavigation, enableNavigation]);
-
 	useInput((_input, key) => {
 		if (key.escape) {
 			onBack();

--- a/ink/configurationWizard/ModelSelectionStep.test.tsx
+++ b/ink/configurationWizard/ModelSelectionStep.test.tsx
@@ -1,13 +1,8 @@
 import { useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelSelectionStep } from './ModelSelectionStep';
-
-vi.mock('ink-stepper', () => ({
-	useStepperInput: vi.fn(),
-}));
 
 vi.mock('ink', async () => {
 	const actual = await vi.importActual('ink');
@@ -18,15 +13,8 @@ vi.mock('ink', async () => {
 });
 
 describe('ModelSelectionStep', () => {
-	const mockDisableNavigation = vi.fn();
-	const mockEnableNavigation = vi.fn();
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useStepperInput as any).mockReturnValue({
-			disableNavigation: mockDisableNavigation,
-			enableNavigation: mockEnableNavigation,
-		});
 	});
 
 	it('renders title and models', () => {

--- a/ink/configurationWizard/ModelSelectionStep.tsx
+++ b/ink/configurationWizard/ModelSelectionStep.tsx
@@ -1,7 +1,6 @@
 import { Select } from '@inkjs/ui';
 import { Box, Text, useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BlinkingTextInput } from '../components/BlinkingTextInput';
 import { emitToListeners } from '../emitters/listener';
 
@@ -18,13 +17,7 @@ export function ModelSelectionStep({
 	onConfirm: (model: string) => void;
 	onBack: () => void;
 }) {
-	const { disableNavigation, enableNavigation } = useStepperInput();
 	const [isCustom, setIsCustom] = useState(false);
-
-	useEffect(() => {
-		disableNavigation();
-		return () => enableNavigation();
-	}, [isCustom, disableNavigation, enableNavigation]);
 
 	useInput((input, key) => {
 		if (key.escape) {

--- a/ink/configurationWizard/ProviderStep.test.tsx
+++ b/ink/configurationWizard/ProviderStep.test.tsx
@@ -1,23 +1,11 @@
-import { useStepperInput } from 'ink-stepper';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProviderStep } from './ProviderStep';
 
-vi.mock('ink-stepper', () => ({
-	useStepperInput: vi.fn(),
-}));
-
 describe('ProviderStep', () => {
-	const mockDisableNavigation = vi.fn();
-	const mockEnableNavigation = vi.fn();
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useStepperInput as any).mockReturnValue({
-			disableNavigation: mockDisableNavigation,
-			enableNavigation: mockEnableNavigation,
-		});
 	});
 
 	it('renders provider selection message', () => {
@@ -25,14 +13,5 @@ describe('ProviderStep', () => {
 		const { lastFrame } = render(<ProviderStep onConfirm={onConfirm} />);
 
 		expect(lastFrame()).toContain('What model provider would you like to use today?');
-	});
-
-	it('disables stepper navigation on mount and enables on unmount', () => {
-		const onConfirm = vi.fn();
-		const { unmount } = render(<ProviderStep onConfirm={onConfirm} />);
-
-		expect(mockDisableNavigation).toHaveBeenCalled();
-		unmount();
-		expect(mockEnableNavigation).toHaveBeenCalled();
 	});
 });

--- a/ink/configurationWizard/ProviderStep.tsx
+++ b/ink/configurationWizard/ProviderStep.tsx
@@ -1,7 +1,6 @@
 import { Select } from '@inkjs/ui';
 import { Box, Text, useInput } from 'ink';
-import { useStepperInput } from 'ink-stepper';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import type { ModelProvider } from '../models/config';
 import { providers } from './providers';
 
@@ -12,7 +11,6 @@ export function ProviderStep(
 		onExit: () => void;
 	},
 ) {
-	const { disableNavigation, enableNavigation } = useStepperInput();
 	const sortedProviders = useMemo(
 		() =>
 			[...providers].sort((a, b) => {
@@ -22,11 +20,6 @@ export function ProviderStep(
 			}),
 		[defaultValue],
 	);
-
-	useEffect(() => {
-		disableNavigation();
-		return () => enableNavigation();
-	}, [disableNavigation, enableNavigation]);
 
 	useInput((input, key) => {
 		if (key.escape) {


### PR DESCRIPTION
Unblocks #142 (`ink-stepper` 0.2.1 → 0.2.3), and removes some plumbing that was never doing anything.

## What was wrong

Every step in the configuration wizard mounted with `disableNavigation()` and unmounted with `enableNavigation()`:

```tsx
const { disableNavigation, enableNavigation } = useStepperInput();

useEffect(() => {
    disableNavigation();
    return () => enableNavigation();
}, [disableNavigation, enableNavigation]);
```

All five steps, unconditionally, for their whole lifetime — so the `Stepper`'s `keyboardNav` bindings were suppressed 100% of the time despite being declared `keyboardNav={true}`. They never ran.

That's because each step already owns its keys: its widget (`Select`, `MultiSelect`, `BlinkingTextInput`) consumes `<enter>` and advances by calling `goNext()` from `onConfirm`, and each step binds `<esc>` itself. The Stepper's bindings would have double-handled `<enter>`, which is exactly what the `disableNavigation()` calls were there to prevent.

## What this does

Says it directly — `keyboardNav={false}` on the `Stepper` — and drops the five identical effects. That part is a **pure no-op**: the same wizard, minus a layer that cancelled itself out.

## Also: the `<esc>` double-fire (review follow-up)

While reviewing, we found a second self-cancelling layer of exactly the same shape. `ConfigurationWizard` ran its own `useInput` that handled `<esc>` by calling `onComplete()`. Ink delivers input to *every* mounted `useInput`, so that fired on top of the active step's own `<esc>` handler: on any step past the first, `<esc>` ran the step's `onBack()` (or left the Model step's custom-entry sub-mode) **and** completed the wizard on top of it — so `<esc>` effectively exited the wizard instead of going back.

Dropping that redundant `<esc>` branch (keeping `ctrl+x → ExitUI`) lets each step own `<esc>` as intended: the first step exits, the rest go back. **This is the one behavior change in the PR** — `<esc>` back-navigation now actually works. Added a `ConfigurationWizard` test asserting the wizard no longer completes on `<esc>`.

## Why it unblocks #142

Through **0.2.1**, `disableNavigation()` only gated the Stepper's own `useInput` handler:

```js
useInput((_input, key) => {
  if (isValidating || isNavigationDisabled) return;   // keyboard only
  ...
}, { isActive: keyboardNav });
```

A programmatic `goNext()` still worked, so the wizard advanced fine.

**0.2.3** added an `isBlocked()` guard to the navigation functions themselves:

```js
const isBlocked = useCallback(() => isValidatingRef.current || isNavigationDisabledRef.current, []);

const goNext = useCallback(async () => {
  if (isBlocked()) return;    // <-- now also swallows programmatic calls
  ...
```

So the same flag every step was setting now also swallowed that step's own explicit `goNext()`. The wizard could never leave step 1 — the frame kept rendering the provider list with the progress dot stuck on the first step, and the four walkthrough tests in `ink/main.test.tsx` failed. Not touching the flag at all makes the wizard behave identically under both versions.

## Verification

Node 24.18.0, full suite (`npx vitest --run`):

| tree | ink-stepper | result |
| --- | --- | --- |
| `main` | 0.2.1 | `ink/main.test.tsx` 6/6 (3 consecutive runs) |
| `main` | 0.2.3 | **4 failed** / 2 passed |
| this branch | 0.2.1 | **344/344** |
| this branch | 0.2.3 | **344/344** |

`npm run lint`, `npm run format`, and `npm run build` all clean.

Re-verified after rebasing onto current `main` (which now carries the AI SDK v4 / `@openai/agents` 0.15 bumps and a CI `build` job) and adding the `<esc>` fix: build, lint, format, and the full suite all green — **345/345**, including the new `ConfigurationWizard` `<esc>` test. The build is now exercised by CI too, not just locally.

This PR is app code only — no manifest or lockfile changes. Once it lands, #142 should go green on a rebase.

## Two notes for follow-up

**1. `ink-stepper` is major-risk while it's 0.x.** This was a *patch* release that changed what `disableNavigation()` means. Worth a Renovate rule treating `ink-stepper` as a major-grade update until 1.0, alongside the existing AI SDK / OpenAI Agents groupings. I'll open an upstream issue too — "suppress the stepper's keybindings but still allow explicit programmatic navigation" is a legitimate use case that 0.2.3 removed with no replacement.

**2. `ink-stepper@0.2.2+` declares a dependency on `ws`** (`^8.21.2`) that is never imported anywhere in its shipped `dist/` — I checked every `import`/`require` in the bundle, and it only pulls `react`, `ink`, and `react/jsx-runtime`. Harmless, but the bump adds a WebSocket library to our production tree for nothing. Also worth mentioning upstream.